### PR TITLE
Update checker: re-add sqrt and add more informative messages

### DIFF
--- a/checker.py
+++ b/checker.py
@@ -6,7 +6,6 @@ from collections import defaultdict
 from re import split as resplit
 
 import math
-import hashlib
 
 def getNorm(n, y, L):
     rhs = []
@@ -19,7 +18,7 @@ def getNorm(n, y, L):
     ret = 0.0
     for i in range(n):
         ret += y[i] * rhs[i]
-    return ret
+    return math.sqrt(ret)
 
 def getL(judge_input):
     # from the raw input
@@ -47,10 +46,6 @@ def getL(judge_input):
     return L
 
 def check(process_output, judge_output, judge_input, point_value, execution_time, **kwargs):
-    dp = dict()
-    m = hashlib.md5()
-    m.update(process_output)
-    md5hash = m.hexdigest()
     try:
         process_lines = process_output.decode("utf-8").split("\n")[:-1]
         judge_lines = judge_output.decode("utf-8").split("\n")[1:-1]
@@ -59,8 +54,7 @@ def check(process_output, judge_output, judge_input, point_value, execution_time
         id = judge_input[0]
         n = int(judge_input[1].split()[0])
 
-        if n != len(process_lines):
-            return False
+        assert n == len(process_lines), "wrong number of lines {}".format(len(process_lines))
 
         barx = [float(x) for x in judge_lines]
         try:
@@ -79,11 +73,9 @@ def check(process_output, judge_output, judge_input, point_value, execution_time
         xDiffNorm = getNorm(n, xDiff, L)
         xNorm = getNorm(n, barx, L)
         if xDiffNorm > 0.1 * xNorm:
-            return CheckerResult(False, 0, "norm out of range {}".format(md5hash))
+            return CheckerResult(False, 0, "norm out of range: xNorm = {}, xDiffNorm = {}, ratio = {}".format(xNorm, xDiffNorm, xDiffNorm / xNorm))
         bestTime = 10.
-        if id in dp:
-            bestTime = dp[id]
         ratio = bestTime / execution_time
-        return CheckerResult(True, point_value * ratio**2, "{}".format(md5hash))
+        return CheckerResult(True, point_value * ratio**2, "norm in range: xNorm = {}, xDiffNorm = {}, ratio = {}".format(xNorm, xDiffNorm, xDiffNorm / xNorm))
     except Exception as e:
         return CheckerResult(False, 0, "{}".format(e))


### PR DESCRIPTION
This fixes the LNorm (there should be a sqrt), removes the extraneous md5 printouts, and prints out the computed norms for debugging.